### PR TITLE
Upgrade project to Liferay 7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,13 +7,13 @@
 *.iml
 *.ipr
 *.iws
-.idea
+.idea/
 
 # Maven
 target/
 
-#Gradle
-.gradle
+# Gradle
+.gradle/
 
 # TestNG
 test-output/
@@ -22,4 +22,4 @@ test-output/
 transaction.log
 
 # Downloads
-arquillian-liferay-bundle
+arquillian-liferay-bundle/

--- a/.mvn/dont-delete-me.txt
+++ b/.mvn/dont-delete-me.txt
@@ -1,0 +1,2 @@
+In order for ${maven.multiModuleProjectDirectory} to work correctly, directory '.mvn'
+is needed in the root directory, see https://stackoverflow.com/a/49528226/1082681.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ after_success:
   - codecov
 
 after_failure:
-  - cat arquillian-liferay-bundle/liferay-portal-7.0-ce-ga3/tomcat-8.0.30/logs/catalina.out
+  - cat arquillian-liferay-bundle/liferay-ce-portal-7.1.0-ga1/tomcat-9.0.6/logs/catalina.out
 

--- a/arquillian-container-liferay/pom.xml
+++ b/arquillian-container-liferay/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>${version.junit}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/arquillian-container-liferay/pom.xml
+++ b/arquillian-container-liferay/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>com.liferay.portal</groupId>
 			<artifactId>com.liferay.portal.kernel</artifactId>
-			<version>2.0.0</version>
+			<version>3.36.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.portlet</groupId>
@@ -38,7 +38,10 @@
 		<dependency>
 			<groupId>com.liferay</groupId>
 			<artifactId>com.liferay.hot.deploy.jmx.listener</artifactId>
-			<version>1.0.1</version>
+
+			<!-- TODO: replace by non-snapshot version as soon as one is available for Liferay 7.1 -->
+
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
+++ b/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
@@ -18,6 +18,7 @@ import com.liferay.arquillian.containter.remote.LiferayRemoteContainerConfigurat
 import com.liferay.arquillian.portal.bundle.PortalURLBundleActivator;
 import com.liferay.arquillian.portal.bundle.servlet.PortalURLServlet;
 import com.liferay.hot.deploy.jmx.listener.mbean.manager.PluginMBeanManager;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,6 +82,12 @@ import org.osgi.jmx.framework.FrameworkMBean;
  * @author Cristina González
  */
 public class LiferayInstallDependenciesObserver {
+
+	public static final boolean IS_WINDOWS =
+		System.getProperty("os.name") != null &&
+			StringUtil.toLowerCase(
+				System.getProperty("os.name")
+			).contains("windows");
 
 	public void startContainer(@Observes StartContainer context)
 		throws Exception {
@@ -395,6 +402,10 @@ public class LiferayInstallDependenciesObserver {
 
 	private void _installBundle(String filePath) throws LifecycleException {
 		try {
+			if (IS_WINDOWS) {
+				filePath = filePath.replaceFirst("^[a-zA-Z]:", "/$0");
+			}
+
 			String pathWithProtocol = "file://" + filePath;
 
 			String contextName = "";

--- a/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
+++ b/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
@@ -402,11 +402,10 @@ public class LiferayInstallDependenciesObserver {
 
 	private void _installBundle(String filePath) throws LifecycleException {
 		try {
-			if (IS_WINDOWS) {
-				filePath = filePath.replaceFirst("^[a-zA-Z]:", "/$0");
-			}
-
-			String pathWithProtocol = "file://" + filePath;
+			String pathWithProtocol = "file://" +
+				(IS_WINDOWS
+					? filePath.replaceFirst("^[a-zA-Z]:", "/$0")
+					: filePath);
 
 			String contextName = "";
 

--- a/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
+++ b/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
@@ -402,10 +402,15 @@ public class LiferayInstallDependenciesObserver {
 
 	private void _installBundle(String filePath) throws LifecycleException {
 		try {
-			String pathWithProtocol = "file://" +
-				(IS_WINDOWS
-					? filePath.replaceFirst("^[a-zA-Z]:", "/$0")
-					: filePath);
+			String pathWithProtocol;
+
+			if (IS_WINDOWS) {
+				pathWithProtocol =
+					"file://" + filePath.replaceFirst("^[a-zA-Z]:", "/$0");
+			}
+			else {
+				pathWithProtocol = "file://" + filePath;
+			}
 
 			String contextName = "";
 

--- a/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
+++ b/arquillian-container-liferay/src/main/java/com/liferay/arquillian/container/remote/installdependency/LiferayInstallDependenciesObserver.java
@@ -335,8 +335,6 @@ public class LiferayInstallDependenciesObserver {
 	}
 
 	private void _initLiferayJMXAttributes() throws LifecycleException {
-		_installBundle(_getMavenDependencyPath(_HOT_DEPLOY_JMX_LISTENER_MVN));
-
 		try {
 
 			// Get the PluginsMBean
@@ -511,9 +509,6 @@ public class LiferayInstallDependenciesObserver {
 	}
 
 	private static final String _FILE_PREFIX = "file";
-
-	private static final String _HOT_DEPLOY_JMX_LISTENER_MVN =
-		"com.liferay:com.liferay.hot.deploy.jmx.listener:1.0.1";
 
 	private static final String _MAVEN_PREFIX = "mvn";
 

--- a/arquillian-deployment-generator-bnd/pom.xml
+++ b/arquillian-deployment-generator-bnd/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>${version.junit}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/arquillian-extension-liferay-example/README.md
+++ b/arquillian-extension-liferay-example/README.md
@@ -6,10 +6,17 @@ This is an example of how to use the Arquillian Liferay Extension.
 
 This example will be executed in the following environment:
 
-* Tomcat Server 7.0.62
-  * JMX enabled and configured.
+* Tomcat Server 9.0.6
+  * JMX enabled and configured. This means that if you do not use the automatically downloaded and configured
+    Liferay + Tomcat bundle, you should deploy and activate the following modules which are not active by default
+    in the plain vanilla Liferay + Tomcat bundle:
+    * `org.apache.aries.jmx:org.apache.aries.jmx.api:1.1.5`
+    * `org.apache.aries:org.apache.aries.util:1.1.1`
+    * `org.apache.aries.jmx:org.apache.aries.jmx.core:1.1.8`
+    * `com.liferay.portal:com.liferay.portal.kernel:2.0.0`
+    * `com.liferay:com.liferay.hot.deploy.jmx.listener:1.0.1`
   * Tomcat Manager installed and configured.
-* Liferay 7.0.0
+* Liferay 7.1.0
 * JUnit 4.12
 
 ##Creating a Liferay Portlet for testing
@@ -615,3 +622,17 @@ Create a new profile *jacoco*  that configure he plugin ''jacoco-maven-plugin'' 
 mvn test -Pjacoco jacoco:report
 ```
 
+## Known problems
+
+### Arquillian integration tests fail with error "Cannot start Karaf container"
+
+Maybe the JMX-related OSGi modules (Apache Aries JMX, Liferay JMX hot-deploy) listed at the beginning of this
+document have been installed in the OSGi runtime (status "Installed" or "Resolved" in GoGo shell), but for
+some reason not started, which sometimes can happen for unknown reasons. I this case
+* connect to the GoGo shell locally via `telnet 11311` (alternatively, use GoGo shell from the Liferay admin GUI),
+* list the corresponding modules via `lb | grep 'JMX|Aries'` and
+* if there are any modules with a status other than "Active", start each service via its numerical ID using
+  the command `start <ID>` (e.g. `start 950`).
+
+Then check again with `lb | grep 'JMX|Aries`. Everything should be listed as "Active" now and the Arquillian
+tests should be able to use JMX hot-deploy and run as expected.

--- a/arquillian-extension-liferay-example/README.md
+++ b/arquillian-extension-liferay-example/README.md
@@ -625,8 +625,11 @@ mvn test -Pjacoco jacoco:report
 
 ### Arquillian integration tests fail with error "Cannot start Karaf container"
 
-Maybe the JMX-related OSGi modules (Apache Aries JMX, Liferay JMX hot-deploy) listed at the beginning of this
-document have been installed in the OSGi runtime (status "Installed" or "Resolved" in GoGo shell), but for
+The simplest reason for this is that Liferay just has not fully started up and activated all necessary modules yet.
+You want to check this possibility first.
+
+Otherwise, maybe the JMX-related OSGi modules (Apache Aries JMX, Liferay JMX hot-deploy) listed at the beginning
+of this document have been installed in the OSGi runtime (status "Installed" or "Resolved" in GoGo shell), but for
 some reason not started, which sometimes can happen for unknown reasons. I this case
 * connect to the GoGo shell locally via `telnet 11311` (alternatively, use GoGo shell from the Liferay admin GUI),
 * list the corresponding modules via `lb | grep 'JMX|Aries'` and

--- a/arquillian-extension-liferay-example/README.md
+++ b/arquillian-extension-liferay-example/README.md
@@ -13,8 +13,7 @@ This example will be executed in the following environment:
     * `org.apache.aries.jmx:org.apache.aries.jmx.api:1.1.5`
     * `org.apache.aries:org.apache.aries.util:1.1.1`
     * `org.apache.aries.jmx:org.apache.aries.jmx.core:1.1.8`
-    * `com.liferay.portal:com.liferay.portal.kernel:2.0.0`
-    * `com.liferay:com.liferay.hot.deploy.jmx.listener:1.0.1`
+    * `com.liferay:com.liferay.hot.deploy.jmx.listener:2.0.0-SNAPSHOT`
   * Tomcat Manager installed and configured.
 * Liferay 7.1.0
 * JUnit 4.12

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -118,14 +118,12 @@
 									<version>1.1.8</version>
 								</artifactItem>
 								<artifactItem>
-									<groupId>com.liferay.portal</groupId>
-									<artifactId>com.liferay.portal.kernel</artifactId>
-									<version>2.0.0</version>
-								</artifactItem>
-								<artifactItem>
 									<groupId>com.liferay</groupId>
 									<artifactId>com.liferay.hot.deploy.jmx.listener</artifactId>
-									<version>1.0.1</version>
+
+									<!-- TODO: replace by non-snapshot version as soon as one is available for Liferay 7.1 -->
+
+									<version>2.0.0-SNAPSHOT</version>
 								</artifactItem>
 							</artifactItems>
 							<outputDirectory>${liferay.home}/osgi/modules</outputDirectory>
@@ -367,9 +365,11 @@
 				<executions>
 					<execution>
 
-						<!-- Create special property 'liferay.home.unix' for resource filtering in file
-						portal-setup-wizard.properties because Liferay does not start correctly on Windows
-						if the path contains backslashes -->
+						<!--
+							Create special property 'liferay.home.unix' for resource filtering in file
+							portal-setup-wizard.properties because Liferay does not start correctly on Windows
+							if the path contains backslashes
+						-->
 
 						<id>regex-property</id>
 						<goals>
@@ -416,5 +416,18 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<repositories>
+
+		<!--
+			TODO: remove as soon as non-snapshot version of com.liferay:com.liferay.hot.deploy.jmx.listener
+			is available for Liferay 7.1
+		-->
+
+		<repository>
+			<id>liferay-snapshots</id>
+			<url>https://repository.liferay.com/nexus/content/repositories/liferay-public-snapshots/</url>
+		</repository>
+	</repositories>
 
 </project>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -73,19 +73,6 @@
 								</goals>
 							</execution>
 							<execution>
-								<id>disable-open-browser</id>
-								<phase>process-test-sources</phase>
-								<configuration>
-									<target>
-										<echo message="create portal-ext.properties" />
-										<echo file="${liferay.home}/portal-ext.properties">browser.launcher.url=</echo>
-									</target>
-								</configuration>
-								<goals>
-									<goal>run</goal>
-								</goals>
-							</execution>
-							<execution>
 								<id>create-file</id>
 								<phase>process-test-sources</phase>
 								<configuration>
@@ -99,6 +86,50 @@
 								</goals>
 							</execution>
 						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<version>3.1.1</version>
+						<executions>
+							<execution>
+								<id>copy-jmx-dependencies</id>
+								<phase>process-test-sources</phase>
+								<goals>
+									<goal>copy</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.apache.aries</groupId>
+									<artifactId>org.apache.aries.util</artifactId>
+									<version>1.1.1</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.aries.jmx</groupId>
+									<artifactId>org.apache.aries.jmx.api</artifactId>
+									<version>1.1.5</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.aries.jmx</groupId>
+									<artifactId>org.apache.aries.jmx.core</artifactId>
+									<version>1.1.8</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>com.liferay.portal</groupId>
+									<artifactId>com.liferay.portal.kernel</artifactId>
+									<version>2.0.0</version>
+								</artifactItem>
+								<artifactItem>
+									<groupId>com.liferay</groupId>
+									<artifactId>com.liferay.hot.deploy.jmx.listener</artifactId>
+									<version>1.0.1</version>
+								</artifactItem>
+							</artifactItems>
+							<outputDirectory>${liferay.home}/osgi/modules</outputDirectory>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>
@@ -316,7 +347,10 @@
 				<targetPath>${liferay.home}</targetPath>
 				<filtering>true</filtering>
 				<directory>${test.resources}/liferay</directory>
-				<includes><include>portal-setup-wizard.properties</include></includes>
+				<includes>
+					<include>portal-ext.properties</include>
+					<include>portal-setup-wizard.properties</include>
+				</includes>
 			</resource>
 		</resources>
 		<testResources>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -16,9 +16,9 @@
 	<properties>
 		<test.resources>src/test/resources</test.resources>
 		<arquillian.liferay.bundle>${maven.multiModuleProjectDirectory}/arquillian-liferay-bundle</arquillian.liferay.bundle>
-		<liferay.home>${arquillian.liferay.bundle}/liferay-ce-portal-7.0-ga3</liferay.home>
-		<liferay.server>${liferay.home}/tomcat-8.0.32</liferay.server>
-		<url.liferay><![CDATA[http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/7.0.2%20GA3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip]]></url.liferay>
+		<liferay.home>${arquillian.liferay.bundle}/liferay-ce-portal-7.1.0-ga1</liferay.home>
+		<liferay.server>${liferay.home}/tomcat-9.0.6</liferay.server>
+		<url.liferay><![CDATA[http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/7.1.0%20GA1/liferay-ce-portal-tomcat-7.1.0-ga1-20180703012531655.zip]]></url.liferay>
 		<browser>phantomjs</browser>
 	</properties>
 

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -148,7 +148,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>exec-maven-plugin</artifactId>
-						<version>1.1</version>
+						<version>1.6.0</version>
 						<executions>
 							<execution>
 								<id>clean-tomcat</id>
@@ -158,15 +158,12 @@
 								</goals>
 								<configuration>
 									<executable>${liferay.executable.stop}</executable>
+
+									<!-- Ignore return code 1 if server is not running -->
+
+									<successCodes>0,1</successCodes>
 								</configuration>
 							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>exec-maven-plugin</artifactId>
-						<version>1.1</version>
-						<executions>
 							<execution>
 								<id>start-tomcat</id>
 								<phase>test-compile</phase>
@@ -175,6 +172,8 @@
 								</goals>
 								<configuration>
 									<executable>${liferay.executable.start}</executable>
+									<async>true</async>
+									<asyncDestroyOnShutdown>true</asyncDestroyOnShutdown>
 								</configuration>
 							</execution>
 							<execution>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -194,11 +194,18 @@
 						<version>1.8</version>
 						<executions>
 							<execution>
+
+								<!--
+									TODO instead: find out how to wait until server has actually started up completely
+								 	as 100 seconds could be way too short (on my machine it is more like 330 s)
+								 	or maybe too long
+								-->
+
 								<id>sleep-for-a-while</id>
 								<phase>test-compile</phase>
 								<configuration>
 									<target>
-										<sleep seconds="100" />
+										<sleep seconds="350" />
 									</target>
 								</configuration>
 								<goals>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -20,6 +20,7 @@
 		<liferay.server>${liferay.home}/tomcat-9.0.6</liferay.server>
 		<url.liferay><![CDATA[http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/7.1.0%20GA1/liferay-ce-portal-tomcat-7.1.0-ga1-20180703012531655.zip]]></url.liferay>
 		<browser>phantomjs</browser>
+		<sleep.seconds>350</sleep.seconds>
 	</properties>
 
 	<profiles>
@@ -207,7 +208,8 @@
 								<phase>test-compile</phase>
 								<configuration>
 									<target>
-										<sleep seconds="350" />
+										<echo message="Sleeping for ${sleep.seconds}, waiting for Liferay to start up" />
+										<sleep seconds="${sleep.seconds}" />
 									</target>
 								</configuration>
 								<goals>
@@ -361,7 +363,7 @@
 				</dependencies>
 				<executions>
 					<execution>
-						<id>copy--jmx-config</id>
+						<id>copy-jmx-config</id>
 						<phase>generate-test-resources</phase>
 						<goals>
 							<goal>copy-resources</goal>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -15,7 +15,7 @@
 
 	<properties>
 		<test.resources>src/test/resources</test.resources>
-		<arquillian.liferay.bundle>${project.basedir}/../arquillian-liferay-bundle</arquillian.liferay.bundle>
+		<arquillian.liferay.bundle>${maven.multiModuleProjectDirectory}/arquillian-liferay-bundle</arquillian.liferay.bundle>
 		<liferay.home>${arquillian.liferay.bundle}/liferay-ce-portal-7.0-ga3</liferay.home>
 		<liferay.server>${liferay.home}/tomcat-8.0.32</liferay.server>
 		<url.liferay><![CDATA[http://downloads.sourceforge.net/project/lportal/Liferay%20Portal/7.0.2%20GA3/liferay-ce-portal-tomcat-7.0-ga3-20160804222206210.zip]]></url.liferay>
@@ -27,7 +27,7 @@
 			<id>download-test-environment</id>
 			<activation>
 				<file>
-					<missing>../arquillian-liferay-bundle/unziped-successfully</missing>
+					<missing>${arquillian.liferay.bundle}/unziped-successfully</missing>
 				</file>
 			</activation>
 			<build>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -316,6 +316,31 @@
 		</testResources>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+
+						<!-- Create special property 'liferay.home.unix' for resource filtering in file
+						portal-setup-wizard.properties because Liferay does not start correctly on Windows
+						if the path contains backslashes -->
+
+						<id>regex-property</id>
+						<goals>
+							<goal>regex-property</goal>
+						</goals>
+						<configuration>
+							<name>liferay.home.unix</name>
+							<value>${liferay.home}</value>
+							<regex>\\</regex>
+							<replacement>/</replacement>
+							<failIfNoMatch>false</failIfNoMatch>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>2.7</version>
 				<dependencies>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -76,6 +76,7 @@
 								<phase>process-test-sources</phase>
 								<configuration>
 									<target>
+										<echo message="create portal-ext.properties" />
 										<echo file="${liferay.home}/portal-ext.properties">browser.launcher.url=</echo>
 									</target>
 								</configuration>
@@ -88,6 +89,7 @@
 								<phase>process-test-sources</phase>
 								<configuration>
 									<target>
+										<echo message="touch file ${arquillian.liferay.bundle}/unziped-successfully" />
 										<touch file="${arquillian.liferay.bundle}/unziped-successfully" />
 									</target>
 								</configuration>

--- a/arquillian-extension-liferay-example/pom.xml
+++ b/arquillian-extension-liferay-example/pom.xml
@@ -291,7 +291,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
+			<version>${version.junit}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/arquillian-extension-liferay-example/src/test/java/com/liferay/arquillian/test/BasicPortletFunctionalTest.java
+++ b/arquillian-extension-liferay-example/src/test/java/com/liferay/arquillian/test/BasicPortletFunctionalTest.java
@@ -64,14 +64,22 @@ public class BasicPortletFunctionalTest {
 	public void testAdd() throws IOException, PortalException {
 		browser.get(_portlerURL.toExternalForm());
 
-		firstParamter.clear();
+		// Useful while debugging for testing manually in browser
+		// System.out.println(_portlerURL.toExternalForm());
 
+		// Clear + enter value
+
+		firstParamter.clear();
 		firstParamter.sendKeys("2");
 
-		secondParameter.clear();
+		// Clear + enter value
 
+		secondParameter.clear();
 		secondParameter.sendKeys("3");
 
+		// Set focus + click
+
+		add.sendKeys(" ");
 		add.click();
 
 		Assert.assertEquals("5", result.getText());
@@ -94,7 +102,9 @@ public class BasicPortletFunctionalTest {
 	@Inject
 	private SampleService _sampleService;
 
-	@FindBy(css = "button[type=submit]")
+	// There are two buttons on the page, also the Liferay search button
+
+	@FindBy(css = "button[type=submit][id^='_arquillian_sample']")
 	private WebElement add;
 
 	@Drone

--- a/arquillian-extension-liferay-example/src/test/java/com/liferay/arquillian/test/InjectionsTest.java
+++ b/arquillian-extension-liferay-example/src/test/java/com/liferay/arquillian/test/InjectionsTest.java
@@ -76,7 +76,7 @@ public class InjectionsTest {
 
 		Release releasePortal = _releaseLocalService.fetchRelease("portal");
 
-		Assert.assertEquals(7002, releasePortal.getBuildNumber());
+		Assert.assertEquals(7100, releasePortal.getBuildNumber());
 	}
 
 	@Test

--- a/arquillian-extension-liferay-example/src/test/resources/liferay/portal-ext.properties
+++ b/arquillian-extension-liferay-example/src/test/resources/liferay/portal-ext.properties
@@ -1,0 +1,2 @@
+browser.launcher.url=
+include-and-override=portal-developer.properties

--- a/arquillian-extension-liferay-example/src/test/resources/liferay/portal-setup-wizard.properties
+++ b/arquillian-extension-liferay-example/src/test/resources/liferay/portal-setup-wizard.properties
@@ -1,3 +1,3 @@
-liferay.home=${liferay.home}
+liferay.home=${liferay.home.unix}
 setup.wizard.add.sample.data=on
 setup.wizard.enabled=false

--- a/arquillian-extension-liferay-example/src/test/resources/tomcat/setenv.bat
+++ b/arquillian-extension-liferay-example/src/test/resources/tomcat/setenv.bat
@@ -12,8 +12,8 @@ set JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.auth
 
 set CATALINA_OPTS="%CATALINA_OPTS% %JMX_OPTS%"
 
-DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=9000,server=y,suspend=n"
 
 set CATALINA_OPTS="%CATALINA_OPTS% %DEBUG_OPTS%"
 
+set DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,address=9000,server=y,suspend=n
 

--- a/arquillian-extension-liferay-example/src/test/resources/tomcat/setenv.bat
+++ b/arquillian-extension-liferay-example/src/test/resources/tomcat/setenv.bat
@@ -3,17 +3,15 @@ if exist "%CATALINA_HOME%/jre${jdk.windows.version}/win" (
                 set JAVA_HOME=
         )
 
-        set "JRE_HOME=%CATALINA_HOME%/jre${jdk.windows.version}/win"
+        set JRE_HOME="%CATALINA_HOME%/jre${jdk.windows.version}/win"
 )
 
-set "CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true  -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=256m"
+set CATALINA_OPTS=%CATALINA_OPTS% -Dfile.encoding=UTF8 -Djava.net.preferIPv4Stack=true -Dorg.apache.catalina.loader.WebappClassLoader.ENABLE_CLEAR_REFERENCES=false -Duser.timezone=GMT -Xmx1024m -XX:MaxPermSize=256m
 
-set JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8099 -Dcom.sun.management.jmxremote.ssl=false"
+set JMX_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8099 -Dcom.sun.management.jmxremote.ssl=false
 
-set CATALINA_OPTS="%CATALINA_OPTS% %JMX_OPTS%"
-
-
-set CATALINA_OPTS="%CATALINA_OPTS% %DEBUG_OPTS%"
+set CATALINA_OPTS=%CATALINA_OPTS% %JMX_OPTS%
 
 set DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,address=9000,server=y,suspend=n
 
+set CATALINA_OPTS=%CATALINA_OPTS% %DEBUG_OPTS%

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,29 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.4.1</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+
+									<!-- We need ${maven.multiModuleProjectDirectory} -->
+
+									<version>3.3.9</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>


### PR DESCRIPTION
**Attention!** This PR also encompasses the yet unmerged PR #24 - sorry for that, but I do not want to wait until that one was also reviewed. The new commits start from today (2018-10-18), i.e. at the time of writing there are three (3) commits specific to this branch.

What was done is mentioned in the commit messages, please read them. Basically it was as follows:
* Upgrade download to Liferay 7.1 + Tomcat 9.0.6
* Upgrade tests to run on LR 7.1
* In 7.0 only one module was missing in order to enable JMX hot-deployment. In 7.1 five (5) modules are needed. Thus I decided to copy them to _osgi/modules_ directly instead of trying to install them from Java, which would be impossible in the first place because `_installBundle(_getMavenDependencyPath(_HOT_DEPLOY_JMX_LISTENER_MVN))` would not work anyway before installing the server-side dependencies to make a call to `_installBundle` possible in the first place.

P.S.: This PR is an indirect result of my troubles related to #19. See also my comments there in order to understand why it is now more complicated to activate JMX hot-deployment in 7.1.

**Update:** Commit fb11446 should fix the problem with module auto-activation mentioned in the troubleshooting section of the read-me file. I still have not removed that section because maybe the problem can still occur under certain circumstances. I can only test on my machine.

**Update 2:** My assumption for the Travis CI build failure is that the initial Liferay start after download + unzip just takes too long, even longer than the 350 s configured in Maven. On my machine it takes twice as long during the first time due to validation: `org.apache.catalina.startup.Catalina.start Server startup in 692020 ms`